### PR TITLE
chore: setup CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: Java CI with Maven
+
+on:
+  pull_request:
+    branches: [ "main", "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn -B package --file backend/pom.xml


### PR DESCRIPTION
### Summary
Add initial Continuous Integration setup using GitHub Actions for the backend project.

### Details
- Added `.github/workflows/ci.yml` file.
- Configured Maven build with Java 21.
- Pipeline runs on pull requests to `develop` and `main` branches.
- Currently executes `mvn -B package --file back-end/pom.xml`.